### PR TITLE
Remove strtolower() for failing tests

### DIFF
--- a/tests/Codesleeve/Stapler/InterpolatorTest.php
+++ b/tests/Codesleeve/Stapler/InterpolatorTest.php
@@ -95,7 +95,7 @@ class InterpolatorTest extends PHPUnit_Framework_TestCase
         $input = '/system/:class_name/:attachment/:id_partition/:style/:filename';
         $interpolatedString = $this->interpolator->interpolate($input, $attachment, 'thumbnail');
 
-        $this->assertEquals('/system/TestModel/photos/000/000/001/thumbnail/test.jpg', $interpolatedString);
+        $this->assertEquals('/system/testmodel/photos/000/000/001/thumbnail/test.jpg', $interpolatedString);
     }
 
     /**
@@ -110,7 +110,7 @@ class InterpolatorTest extends PHPUnit_Framework_TestCase
         $input = '/system/:namespace/:attachment/:id_partition/:style/:filename';
         $interpolatedString = $this->interpolator->interpolate($input, $attachment, 'thumbnail');
 
-        $this->assertEquals('/system/Foo/Faz/Baz/photos/000/000/001/thumbnail/test.jpg', $interpolatedString);
+        $this->assertEquals('/system/foo/faz/baz/photos/000/000/001/thumbnail/test.jpg', $interpolatedString);
     }
 
     /**


### PR DESCRIPTION
For issue https://github.com/brunodevel/stapler/issues/1

Failing test info:

```
1) Codesleeve\Stapler\InterpolatorTest::it_should_be_able_to_interpolate_a_string_using_a_class_name
Failed asserting that two strings are equal.                                                        
--- Expected                                                                                        
+++ Actual                                                                                          
@@ @@                                                                                               
-'/system/TestModel/photos/000/000/001/thumbnail/test.jpg'                                          
+'/system/testmodel/photos/000/000/001/thumbnail/test.jpg'                                          

C:\laragon\www\stapler\tests\Codesleeve\Stapler\InterpolatorTest.php:98                             

2) Codesleeve\Stapler\InterpolatorTest::it_should_be_able_to_interpolate_a_string_using_a_namespace 
Failed asserting that two strings are equal.                                                        
--- Expected                                                                                        
+++ Actual                                                                                          
@@ @@                                                                                               
-'/system/Foo/Faz/Baz/photos/000/000/001/thumbnail/test.jpg'                                        
+'/system/foo/faz/baz/photos/000/000/001/thumbnail/test.jpg'                                        
```

I assumed you wanted the string's case to remain based on expected result from the test so removed `strtolower()`, please advise if expected result should instead be altered.

Still have this issue when running tests (unsure how to fix):

```
Starting test 'Codesleeve\Stapler\Factories\AttachmentTest::it_should_be_able_to_build_an_attachment_object'.                                                                

Fatal error: Cannot declare class Codesleeve\Stapler\Factories\Attachment 
because the name is already in use in 
C:\laragon\www\stapler\src\Factories\Attachment.php on line 8
```
